### PR TITLE
Feat/port var

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -12,16 +12,24 @@ else
 	if [[ ${REDIRECT_TARGET:length-1:1} != "/" ]]; then
 		REDIRECT_TARGET="$REDIRECT_TARGET/"
 	fi
+fi
 
-	echo "Redirecting HTTP requests to ${REDIRECT_TARGET}..."
+# Default to 80
+export LISTEN="80"
+# Listen to PORT variable given on Cloud Run Context
+if [ ! -z "$PORT" ]; then
+	LISTEN="$PORT"
 fi
 
 cat <<EOF > /etc/nginx/conf.d/default.conf
 server {
-	listen 80;
+	listen ${LISTEN};
 
-	rewrite ^/(.*)\$ $REDIRECT_TARGET\$1 permanent;
+	rewrite ^/(.*)\$ ${REDIRECT_TARGET}\$1 permanent;
 }
 EOF
+
+
+echo "Listening to $LISTEN, Redirecting HTTP requests to ${REDIRECT_TARGET}..."
 
 exec nginx -g "daemon off;"

--- a/start.sh
+++ b/start.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # Default to 80
-export LISTEN="80"
+LISTEN="80"
 # Listen to PORT variable given on Cloud Run Context
 if [ ! -z "$PORT" ]; then
 	LISTEN="$PORT"


### PR DESCRIPTION
Container should use PORT env var in order to launch application on Google Cloud Run

https://cloud.google.com/run/

This PR does not break default behavior as the default port stay 80.