### PR TITLE
Use Nginx stable-alpine-slim as base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15-alpine
+FROM nginx:stable-alpine-slim
 
 COPY start.sh /usr/local/bin/
 


### PR DESCRIPTION
alpine1.15 has last been updated in May 2019 (security issues?). Using `stable-alpine-slim` you can be assured the latest stable is being used, while chances are very slim that it will break the functionality.