### PR TITLE
Allow not retaining the path, do not add trailing slashes and update nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.15-alpine
+FROM nginx:1.25-alpine
 
 COPY start.sh /usr/local/bin/
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Possible redirect targets include domains (`mydomain.net`), paths (`mydomain.net
 **Example:** `$ docker run --rm -d -e REDIRECT_TARGET=mydomain.net -p 80:80 morbz/docker-web-redirect`
 
 ### Paths are retained ###
-The URL path and GET parameters are retained. That means that a request to `http://myolddomain.net/index.php?page=2` will be redirected to `http://mydomain.net/index.php?page=2` when `REDIRECT_TARGET=mydomain.net` is set.
+The URL path and GET parameters are retained by default. That means that a request to `http://myolddomain.net/index.php?page=2` will be redirected to `http://mydomain.net/index.php?page=2` when `REDIRECT_TARGET=mydomain.net` is set. If you do not want to retain the path and GET parameters, set the environment variable `RETAIN_PATH` to `false`.
 
 ### Permanent redirects ###
 Redirects are, by default, permanent (HTTP status code 301). That means browsers will cache the redirect and will go directly to the new site on further requests. Also search engines will recognize the new domain and change their URLs. This means this image is not suitable for temporary redirects e.g. for site maintenance.

--- a/start.sh
+++ b/start.sh
@@ -11,11 +11,6 @@ else
 	if ! [[ $REDIRECT_TARGET =~ ^https?:// ]]; then
 		REDIRECT_TARGET="http://$REDIRECT_TARGET"
 	fi
-
-	# Add trailing slash
-	if [[ ${REDIRECT_TARGET:length-1:1} != "/" ]]; then
-		REDIRECT_TARGET="$REDIRECT_TARGET/"
-	fi
 fi
 
 # Default to 80
@@ -29,7 +24,7 @@ cat <<EOF > /etc/nginx/conf.d/default.conf
 server {
 	listen ${LISTEN};
 
-	rewrite ^/(.*)\$ ${REDIRECT_TARGET}\$1 ${REDIRECT_TYPE};
+	rewrite ^(.*)\$ ${REDIRECT_TARGET}\$1 ${REDIRECT_TYPE};
 }
 EOF
 

--- a/start.sh
+++ b/start.sh
@@ -20,13 +20,24 @@ if [ ! -z "$PORT" ]; then
 	LISTEN="$PORT"
 fi
 
-cat <<EOF > /etc/nginx/conf.d/default.conf
-server {
-	listen ${LISTEN};
+: ${RETAIN_PATH:='true'}
+if [ "$RETAIN_PATH" = "true" ]; then
+	cat <<EOF > /etc/nginx/conf.d/default.conf
+	server {
+		listen ${LISTEN};
 
-	rewrite ^(.*)\$ ${REDIRECT_TARGET}\$1 ${REDIRECT_TYPE};
-}
+		rewrite ^(.*)\$ ${REDIRECT_TARGET}\$1 ${REDIRECT_TYPE};
+	}
 EOF
+else
+	cat <<EOF > /etc/nginx/conf.d/default.conf
+	server {
+		listen ${LISTEN};
+
+		rewrite ^(.*)\$ ${REDIRECT_TARGET} ${REDIRECT_TYPE};
+	}
+EOF
+fi
 
 
 echo "Listening to $LISTEN, Redirecting HTTP requests to ${REDIRECT_TARGET}..."


### PR DESCRIPTION
- Update nginx to 1.25 (latest version at the time of writing)
- Do not append trailing slashes to the redirect target (fixes #10)
- Add `RETAIN_PATH` env variable that can be set to `false` to _not_ retain the path, ie. to redirect _any_ path to the same target (defaults to `true` to keep the old behavior)

Unlike eg. #4, this PR should not break existing setups.